### PR TITLE
fix case with bibliography and explicit extension

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
 # Standard hooks
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.4.0
   hooks:
   - id: check-case-conflict
   - id: check-docstring-first
@@ -32,19 +32,19 @@ repos:
 
 # Python linter (Flake8)
 - repo: https://github.com/PyCQA/flake8
-  rev: 4.0.1
+  rev: 6.0.0
   hooks:
   - id: flake8
 
 # Python formatting
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 23.1.0
   hooks:
   - id: black
 
 # Python type checking
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v0.931'
+  rev: 'v1.1.1'
   hooks:
   - id: mypy
     args: [--allow-redefinition, --ignore-missing-imports]

--- a/autobib/util.py
+++ b/autobib/util.py
@@ -30,9 +30,16 @@ def get_aux_bibdata(aux: Path) -> List[Path]:
         m = re.search(r"\\bibdata{([^}]+)}", f.read())
     # split comma-separated entries
     names = m.group(1).split(",") if m else []
-    # make unique while preserving order
-    dir = aux.parent
-    return [dir / f"{name}.bib" for name in dict.fromkeys(names)]
+    pdir = aux.parent
+    files = []
+    for name in names:
+        if name.endswith(".bib"):
+            fn = pdir / name
+        else:
+            fn = pdir / f"{name}.bib"
+        if fn not in files:
+            files.append(fn)
+    return files
 
 
 def get_aux_keys(aux: Path) -> Set[Key]:


### PR DESCRIPTION
Process `\bibliography{some_file.bib}` correctly. Previously it was always assumed that the file extension is not explicitly given.